### PR TITLE
Fix minor error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ yarn run build
 ```
 or
 ```sh
-yarn run build
+npm run build
 ```
 
 You can now deploy the contents of the `build` directory to production!


### PR DESCRIPTION
Fix a minor copy-paste error in README.md. Command to build with npm should be npm run build