### PR TITLE
Don't expose store to Redux Tools in production

### DIFF
--- a/utils/store.js
+++ b/utils/store.js
@@ -9,7 +9,7 @@ const defaultState = {
 const isClient = typeof window !== 'undefined';
 
 const enhancers = compose(
-	typeof window !== 'undefined' ? window.devToolsExtension && window.devToolsExtension() : f => f
+	typeof window !== 'undefined' && process.env.NODE_ENV != 'production' ? window.devToolsExtension && window.devToolsExtension() : f => f
 );
 
 const createStoreWithMiddleware = applyMiddleware()(createStore);

--- a/utils/store.js
+++ b/utils/store.js
@@ -9,7 +9,7 @@ const defaultState = {
 const isClient = typeof window !== 'undefined';
 
 const enhancers = compose(
-	typeof window !== 'undefined' && process.env.NODE_ENV != 'production' ? window.devToolsExtension && window.devToolsExtension() : f => f
+	typeof window !== 'undefined' && process.env.NODE_ENV !== 'production' ? window.devToolsExtension && window.devToolsExtension() : f => f
 );
 
 const createStoreWithMiddleware = applyMiddleware()(createStore);


### PR DESCRIPTION
This might be considered a bit opinionated, but for security reasons, I think **the store should only be exposed to React Tools in development mode**.

Adding a simple check should do the trick.

What do you think?