### PR TITLE
Create .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    [ "next/babel" ]
+  ]
+}


### PR DESCRIPTION
This config is needed because the yarn build command breaks after installation (Module build failed: Error: .presets must be an array, or undefined).

With this config default next.js babel config is ensured.